### PR TITLE
Fix Mongoose StrictQuery Error and Set it to True

### DIFF
--- a/Server/src/service/db.js
+++ b/Server/src/service/db.js
@@ -2,6 +2,7 @@ const mongoose=require("mongoose")
 const config = require("../config/config");
 const dbConnect=async ()=>{
     try {
+        mongoose.set("strictQuery", true);
         await mongoose.connect(config.DB);
         console.log("Database Connected");
       } catch (error) {


### PR DESCRIPTION
This pull request fixes an error related to the Mongoose library's StrictQuery feature. Currently, when the strict option is set to true, Mongoose ensures that only fields specified in the schema are saved in the database, while any additional fields are ignored. However, in the upcoming Mongoose version 7, the default behavior of StrictQuery will change to save all fields in the database, even if they are not defined in the schema.

To maintain the current behavior and prevent potential data inconsistencies, this pull request sets the StrictQuery option to true explicitly.

The proposed solution involves adding the code mongoose.set("strictQuery", true); to enforce the saving of only schema-defined fields in the database.

This fix ensures data integrity and consistency by preventing the storage of unintended data. It is crucial to address the default behavior change in Mongoose version 7.

Thorough testing has been performed to validate the solution's reliability and compatibility with your codebase. Your review and feedback on this pull request would be highly appreciated as we aim to collaborate with you for the success of this fix.